### PR TITLE
Add legal pages and fix footer links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import PrivacyPolicy from "./pages/PrivacyPolicy";
+import TermsOfService from "./pages/TermsOfService";
 
 const queryClient = new QueryClient();
 
@@ -16,6 +18,8 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+          <Route path="/terms-of-service" element={<TermsOfService />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -38,8 +38,8 @@ const Footer = () => {
         <div className="flex flex-col md:flex-row items-center justify-between text-sm text-foreground/50">
           <p>&copy; {currentYear} Nuvem Labs. All rights reserved.</p>
           <div className="flex space-x-6 mt-4 md:mt-0">
-            <a href="#" className="hover:text-foreground transition-colors">Privacy Policy</a>
-            <a href="#" className="hover:text-foreground transition-colors">Terms of Service</a>
+            <a href="/privacy-policy" className="hover:text-foreground transition-colors">Privacy Policy</a>
+            <a href="/terms-of-service" className="hover:text-foreground transition-colors">Terms of Service</a>
           </div>
         </div>
       </div>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,0 +1,73 @@
+import { useEffect } from 'react';
+
+const PrivacyPolicy = () => {
+  useEffect(() => {
+    document.title = 'Privacy Policy - Nuvem Labs';
+  }, []);
+
+  return (
+    <div className="min-h-screen container mx-auto px-4 py-12 space-y-6">
+      <h1 className="text-3xl font-bold">Privacy Policy</h1>
+      <p className="text-foreground/70">
+        At Nuvem Labs we build AI-powered applications that help businesses move
+        faster. Protecting your data is an important part of that mission.
+      </p>
+
+      <div className="space-y-4 text-foreground/70">
+        <section>
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Information We Collect
+          </h2>
+          <p>
+            We collect basic contact details when you reach out to us along with
+            usage information from our website and services. This allows us to
+            respond to inquiries and improve our offerings.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            How We Use Your Data
+          </h2>
+          <p>
+            The data we gather is used solely to communicate with you, maintain
+            our services, and understand how visitors interact with our site. We
+            never sell your information.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Cookies and Analytics
+          </h2>
+          <p>
+            Like most companies we use cookies and similar technologies to track
+            anonymous usage statistics. You can disable cookies in your browser
+            if you prefer not to share this information.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Your Choices
+          </h2>
+          <p>
+            If you would like to view, update, or delete the personal data we
+            hold about you, simply contact us at
+            <a href="mailto:info@nuvemlabs.co.nz" className="text-primary underline ml-1">info@nuvemlabs.co.nz</a>.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground mb-2">Contact</h2>
+          <p>
+            Questions about this policy or our data practices? Email us and
+            we&apos;ll be happy to help.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default PrivacyPolicy;

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -1,0 +1,64 @@
+import { useEffect } from 'react';
+
+const TermsOfService = () => {
+  useEffect(() => {
+    document.title = 'Terms of Service - Nuvem Labs';
+  }, []);
+
+  return (
+    <div className="min-h-screen container mx-auto px-4 py-12 space-y-6">
+      <h1 className="text-3xl font-bold">Terms of Service</h1>
+      <p className="text-foreground/70">
+        These terms outline the rules for using Nuvem Labs&apos; website and
+        services. By accessing our site you agree to them.
+      </p>
+
+      <div className="space-y-4 text-foreground/70">
+        <section>
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Using Our Services
+          </h2>
+          <p>
+            We provide AI-driven development and automation solutions. You agree
+            to use our services only for lawful purposes and in accordance with
+            all applicable regulations.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Intellectual Property
+          </h2>
+          <p>
+            All content on this site including text, graphics and logos is the
+            property of Nuvem Labs. You may not reproduce or distribute it
+            without permission.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Limitation of Liability
+          </h2>
+          <p>
+            We strive to keep our services reliable but we make no warranties.
+            Nuvem Labs is not liable for any damages arising from the use of our
+            site or services.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Contact Us
+          </h2>
+          <p>
+            If you have questions about these terms, reach us at
+            <a href="mailto:info@nuvemlabs.co.nz" className="text-primary underline ml-1">info@nuvemlabs.co.nz</a>.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default TermsOfService;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -168,5 +169,5 @@ export default {
 			},
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- create Privacy Policy and Terms of Service pages
- link footer items to the new pages
- register the new routes in the app router
- add creative content for the legal pages
- fix lint errors in ui components and tailwind config

## Testing
- `npm run lint`